### PR TITLE
Update docker-compose.yml to support Mac M1 Setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     # db mysql
     db:
         image: mysql:5.7.22
+        platform: linux/x86_64
         restart: unless-stopped
         environment:
             MYSQL_DATABASE: ${DB_DATABASE:-laravel}


### PR DESCRIPTION
Referência: https://stackoverflow.com/questions/65456814/docker-apple-silicon-m1-preview-mysql-no-matching-manifest-for-linux-arm64-v8